### PR TITLE
Adds worktree selection support

### DIFF
--- a/.changeset/worktree-select-support.md
+++ b/.changeset/worktree-select-support.md
@@ -1,0 +1,6 @@
+---
+'@portmux/core': minor
+'@portmux/cli': minor
+---
+
+Add git worktree aware selection plus per-worktree instance tracking so multiple checkouts can be started independently.

--- a/packages/cli/src/commands/ps.test.ts
+++ b/packages/cli/src/commands/ps.test.ts
@@ -48,14 +48,18 @@ describe('psCommand', () => {
   it('prints process table and colored summary for running and error statuses', async () => {
     listProcesses.mockReturnValue([
       {
-        groupKey: 'repo1',
-        group: 'ws-one',
+        groupKey: '/repo/main',
+        group: 'instance-one',
+        groupLabel: 'repo-one:main',
+        repositoryName: 'repo-one',
+        groupDefinitionName: 'ws-one',
         process: 'api',
         status: 'Running' as const,
         pid: 123,
+        worktreePath: '/repo/main',
       },
       {
-        group: 'ws-two',
+        group: 'instance-two',
         process: 'worker',
         status: 'Error' as const,
       },
@@ -64,11 +68,11 @@ describe('psCommand', () => {
     await runPs();
 
     expect(console.table).toHaveBeenCalledWith([
-      { Repository: 'repo1', Group: 'ws-one', Process: 'api', Status: 'Running', PID: 123 },
-      { Repository: '-', Group: 'ws-two', Process: 'worker', Status: 'Error', PID: '-' },
+      { Repository: 'repo-one:main (/repo/main)', Group: 'ws-one', Process: 'api', Status: 'Running', PID: 123 },
+      { Repository: 'instance-two', Group: 'instance-two', Process: 'worker', Status: 'Error', PID: '-' },
     ]);
-    expect(console.log).toHaveBeenCalledWith('  ✓ repo1 (ws-one)/api (PID: 123)');
-    expect(console.log).toHaveBeenCalledWith('  ✗ ws-two/worker');
+    expect(console.log).toHaveBeenCalledWith('  ✓ repo-one:main (/repo/main)/api (PID: 123)');
+    expect(console.log).toHaveBeenCalledWith('  ✗ instance-two/worker');
     expect(process.exit).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/commands/ps.ts
+++ b/packages/cli/src/commands/ps.ts
@@ -4,6 +4,19 @@ import chalk from 'chalk';
 
 export const psCommand: ReturnType<typeof createPsCommand> = createPsCommand();
 
+function formatRepositoryLabel(process: ReturnType<typeof ProcessManager.listProcesses>[number]): string {
+  const label = process.groupLabel ?? process.repositoryName ?? process.group;
+  const path = process.worktreePath ?? process.groupKey;
+  if (path) {
+    return `${label} (${path})`;
+  }
+  return label;
+}
+
+function formatGroupDisplay(process: ReturnType<typeof ProcessManager.listProcesses>[number]): string {
+  return process.groupDefinitionName ?? process.groupLabel ?? process.group;
+}
+
 function createPsCommand(): Command {
   return new Command('ps').description('Show running process states').action(() => {
     try {
@@ -16,8 +29,8 @@ function createPsCommand(): Command {
 
       // Display rows as a table
       const tableData = processes.map((p) => ({
-        Repository: p.groupKey ?? '-',
-        Group: p.group,
+        Repository: formatRepositoryLabel(p),
+        Group: formatGroupDisplay(p),
         Process: p.process,
         Status: p.status,
         PID: p.pid ?? '-',
@@ -29,13 +42,9 @@ function createPsCommand(): Command {
       processes.forEach((p) => {
         if (p.status === 'Running') {
           const pidText = p.pid !== undefined ? String(p.pid) : 'unknown';
-          const repositoryLabel = p.groupKey ?? p.group;
-          const repositorySuffix = p.groupKey && p.groupKey !== p.group ? ` (${p.group})` : '';
-          console.log(chalk.green(`  ✓ ${repositoryLabel}${repositorySuffix}/${p.process} (PID: ${pidText})`));
+          console.log(chalk.green(`  ✓ ${formatRepositoryLabel(p)}/${p.process} (PID: ${pidText})`));
         } else if (p.status === 'Error') {
-          const repositoryLabel = p.groupKey ?? p.group;
-          const repositorySuffix = p.groupKey && p.groupKey !== p.group ? ` (${p.group})` : '';
-          console.log(chalk.red(`  ✗ ${repositoryLabel}${repositorySuffix}/${p.process}`));
+          console.log(chalk.red(`  ✗ ${formatRepositoryLabel(p)}/${p.process}`));
         }
       });
     } catch (error) {

--- a/packages/cli/src/commands/stop.test.ts
+++ b/packages/cli/src/commands/stop.test.ts
@@ -65,6 +65,7 @@ describe('stopCommand', () => {
     await runStopCommand();
 
     expect(console.error).toHaveBeenCalledWith('Error: Multiple groups are running. Please specify a group name.');
+    expect(console.error).toHaveBeenCalledWith('Available groups:\n  - ws1 [ws1]\n  - ws2 [ws2]');
     expect(process.exit).toHaveBeenCalledWith(1);
     expect(ProcessManager.stopProcess).not.toHaveBeenCalled();
   });
@@ -80,8 +81,8 @@ describe('stopCommand', () => {
 
     expect(LockManager.withLock).toHaveBeenCalledWith('group', 'ws1', expect.any(Function));
     expect(ProcessManager.stopProcess).toHaveBeenCalledTimes(2);
-    expect(console.log).toHaveBeenCalledWith('✓ Stopped process "api"');
-    expect(console.log).toHaveBeenCalledWith('✓ Stopped process "worker"');
+    expect(console.log).toHaveBeenCalledWith('✓ Stopped process "api" (ws1)');
+    expect(console.log).toHaveBeenCalledWith('✓ Stopped process "worker" (ws1)');
   });
 
   it('reports when targeted process is not running', async () => {

--- a/packages/cli/src/utils/group-instance.ts
+++ b/packages/cli/src/utils/group-instance.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'crypto';
+
+function slugifyBranch(branch?: string): string | undefined {
+  if (!branch) {
+    return undefined;
+  }
+  return branch
+    .replace(/^refs\/heads\//, '')
+    .replace(/[^a-zA-Z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function buildGroupInstanceId(
+  repositoryName: string,
+  groupDefinitionName: string,
+  worktreePath: string
+): string {
+  const hash = createHash('sha1').update(worktreePath).digest('hex').slice(0, 10);
+  return `${repositoryName}::${groupDefinitionName}::${hash}`;
+}
+
+export function buildGroupLabel(repositoryName: string, branchLabel?: string): string {
+  const normalizedBranch = slugifyBranch(branchLabel);
+  if (!normalizedBranch) {
+    return repositoryName;
+  }
+  return `${repositoryName}:${normalizedBranch}`;
+}

--- a/packages/core/src/group/group-manager.test.ts
+++ b/packages/core/src/group/group-manager.test.ts
@@ -200,6 +200,28 @@ describe('GroupManager', () => {
 
       cleanupTempDir(root);
     });
+
+    it('loads configuration from a custom worktree path when provided', () => {
+      const { root: mainRoot } = createTempProject();
+      const { root: worktreeRoot, configPath: worktreeConfigPath } = createTempProject();
+      const globalConfig: GlobalConfig = {
+        repositories: {
+          'test-group': {
+            path: mainRoot,
+            group: 'default',
+          },
+        },
+      };
+      createGlobalConfig(globalConfig);
+
+      const resolved = GroupManager.resolveGroupByName('test-group', { worktreePath: worktreeRoot });
+
+      expect(resolved.path).toBe(realpathSync(worktreeRoot));
+      expect(resolved.projectConfigPath).toBe(realpathSync(worktreeConfigPath));
+
+      cleanupTempDir(mainRoot);
+      cleanupTempDir(worktreeRoot);
+    });
   });
 
   describe('resolveGroupAuto', () => {

--- a/packages/core/src/process/process-manager.ts
+++ b/packages/core/src/process/process-manager.ts
@@ -17,6 +17,11 @@ export interface ProcessStartOptions {
   projectRoot?: string; // Directory containing portmux.config.json
   ports?: number[]; // Array of ports to reserve
   groupKey?: string; // Repository path (from global config) for display
+  groupLabel?: string; // Human readable label (e.g., repo:branch)
+  repositoryName?: string;
+  groupDefinitionName?: string;
+  worktreePath?: string;
+  branch?: string;
 }
 
 /** Process start error */
@@ -52,6 +57,11 @@ export class ProcessRestartError extends PortmuxError {
 export interface ProcessInfo {
   group: string;
   groupKey?: string;
+  groupLabel?: string;
+  repositoryName?: string;
+  groupDefinitionName?: string;
+  worktreePath?: string;
+  branch?: string;
   process: string;
   status: ProcessStatus;
   pid?: number;
@@ -218,7 +228,12 @@ export const ProcessManager = {
     // Persist the state
     const state: ProcessState = {
       group,
-      groupKey: options.groupKey ?? group,
+      groupKey: options.groupKey ?? options.worktreePath ?? group,
+      ...(options.groupLabel !== undefined && { groupLabel: options.groupLabel }),
+      ...(options.repositoryName !== undefined && { repositoryName: options.repositoryName }),
+      ...(options.groupDefinitionName !== undefined && { groupDefinitionName: options.groupDefinitionName }),
+      ...(options.worktreePath !== undefined && { worktreePath: options.worktreePath }),
+      ...(options.branch !== undefined && { branch: options.branch }),
       process: processName,
       status: 'Running',
       pid,
@@ -367,6 +382,11 @@ export const ProcessManager = {
       processes.push({
         group: state.group,
         ...(state.groupKey !== undefined && { groupKey: state.groupKey }),
+        ...(state.groupLabel !== undefined && { groupLabel: state.groupLabel }),
+        ...(state.repositoryName !== undefined && { repositoryName: state.repositoryName }),
+        ...(state.groupDefinitionName !== undefined && { groupDefinitionName: state.groupDefinitionName }),
+        ...(state.worktreePath !== undefined && { worktreePath: state.worktreePath }),
+        ...(state.branch !== undefined && { branch: state.branch }),
         process: state.process,
         status,
         ...(state.pid !== undefined && { pid: state.pid }),
@@ -410,6 +430,11 @@ export const ProcessManager = {
       const errorState: ProcessState = {
         group,
         groupKey: options.groupKey ?? restartPlan.previousState?.groupKey ?? group,
+        ...(options.groupLabel !== undefined && { groupLabel: options.groupLabel }),
+        ...(options.repositoryName !== undefined && { repositoryName: options.repositoryName }),
+        ...(options.groupDefinitionName !== undefined && { groupDefinitionName: options.groupDefinitionName }),
+        ...(options.worktreePath !== undefined && { worktreePath: options.worktreePath }),
+        ...(options.branch !== undefined && { branch: options.branch }),
         process: processName,
         status: 'Error',
         error: error instanceof Error ? error.message : String(error),

--- a/packages/core/src/state/state-manager.ts
+++ b/packages/core/src/state/state-manager.ts
@@ -14,6 +14,11 @@ export type ProcessStatus = 'Running' | 'Stopped' | 'Error';
 export interface ProcessState {
   group: string;
   groupKey?: string;
+  groupLabel?: string;
+  repositoryName?: string;
+  groupDefinitionName?: string;
+  worktreePath?: string;
+  branch?: string;
   process: string;
   status: ProcessStatus;
   pid?: number;


### PR DESCRIPTION
Improves the CLI to be aware of git worktrees, allowing users to select and manage processes in different worktrees independently.

This change introduces per-worktree instance tracking, enabling multiple checkouts to be started without conflicts.

Updates the `select`, `start`, `stop`, `ps`, and `logs` commands to work with git worktrees. It also introduces logic to build group instance IDs and labels based on the worktree path, and to filter states by worktree path or group key.