### PR TITLE
Fixes process stop error

### DIFF
--- a/packages/core/src/state/state-manager.ts
+++ b/packages/core/src/state/state-manager.ts
@@ -22,6 +22,7 @@ export interface ProcessState {
   process: string;
   status: ProcessStatus;
   pid?: number;
+  command?: string;
   error?: string;
   startedAt?: string; // ISO 8601 timestamp
   stoppedAt?: string; // ISO 8601 timestamp


### PR DESCRIPTION
Ensures processes are stopped only if the PID and command match the recorded state. This prevents unintended termination of other processes that might have reused the same PID. Also, ensures deletion of stale process states in cases where the process has been replaced by another one with the same PID.