### PR TITLE
Fixes global config validation during init

### DIFF
--- a/.changeset/fix-init-global-validation.md
+++ b/.changeset/fix-init-global-validation.md
@@ -1,0 +1,5 @@
+---
+'@portmux/core': patch
+---
+
+Fix validation of the global config during init so only entries targeting the current project are checked.

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -271,8 +271,15 @@ export const ConfigManager = {
   validateGlobalConfig(globalConfig: GlobalConfig, projectConfig: PortMuxConfig, projectConfigPath: string): void {
     ensureUniqueRepositoryNames(globalConfig);
 
-    // Verify external references
+    const normalizedProjectConfigPath = normalizePath(projectConfigPath);
+
+    // Verify external references only for repositories that point to the provided project config
     for (const [repositoryName, repository] of Object.entries(globalConfig.repositories)) {
+      const repositoryConfigPath = normalizePath(join(repository.path, 'portmux.config.json'));
+      if (repositoryConfigPath !== normalizedProjectConfigPath) {
+        continue;
+      }
+
       validateRepositoryReference(repositoryName, repository.group, projectConfig, projectConfigPath);
     }
   },


### PR DESCRIPTION
Ensures that the global config validation during the init process only checks entries targeting the current project.

This prevents issues where unrelated repositories in the global config cause validation failures during the initialization of a new project.