### PR TITLE
Prioritizes current repo in select groups

### DIFF
--- a/.changeset/prioritize-current-repo.md
+++ b/.changeset/prioritize-current-repo.md
@@ -1,0 +1,5 @@
+---
+'@portmux/core': patch
+---
+
+Prioritize the current git repository when building selectable groups for `portmux select`.

--- a/packages/core/src/group/group-manager.ts
+++ b/packages/core/src/group/group-manager.ts
@@ -395,6 +395,8 @@ export const GroupManager = {
     const includeAll = options?.includeAll ?? false;
     const runningGroups = getRunningWorktrees();
     const selections: GroupSelection[] = [];
+    const currentGitRoot = findGitRoot(process.cwd());
+    const normalizedCurrentGitRoot = currentGitRoot ? normalizePath(currentGitRoot) : null;
 
     for (const mergedRepository of Object.values(mergedConfig.repositories)) {
       const normalizedRepositoryPath = normalizePath(mergedRepository.path);
@@ -460,6 +462,16 @@ export const GroupManager = {
     }
 
     selections.sort((a, b) => {
+      const aIsCurrent =
+        normalizedCurrentGitRoot !== null &&
+        (a.repositoryPath === normalizedCurrentGitRoot || a.worktreePath === normalizedCurrentGitRoot);
+      const bIsCurrent =
+        normalizedCurrentGitRoot !== null &&
+        (b.repositoryPath === normalizedCurrentGitRoot || b.worktreePath === normalizedCurrentGitRoot);
+      if (aIsCurrent !== bIsCurrent) {
+        return aIsCurrent ? -1 : 1;
+      }
+
       const repoCompare = a.repositoryName.localeCompare(b.repositoryName);
       if (repoCompare !== 0) {
         return repoCompare;

--- a/portmux.config.json
+++ b/portmux.config.json
@@ -1,16 +1,12 @@
 {
-  "$schema": "./packages/cli/schemas/portmux.config.schema.json",
+  "$schema": "node_modules/@portmux/cli/schemas/portmux.config.schema.json",
   "groups": {
-    "test": {
-      "description": "Test group",
+    "debug": {
+      "description": "",
       "commands": [
         {
           "name": "sleep",
-          "command": "sleep 100"
-        },
-        {
-          "name": "node-test",
-          "command": "node -e \"setTimeout(() => {}, 100000)\""
+          "command": "sleep 1000"
         }
       ]
     }


### PR DESCRIPTION
Ensures the current Git repository is prioritized
when building selectable groups for `portmux select`. This improves the user experience by placing the
most relevant repository at the top of the selection list.