### PR TITLE
Adds `portmux sync` command

### DIFF
--- a/.changeset/add-portmux-sync-command.md
+++ b/.changeset/add-portmux-sync-command.md
@@ -1,0 +1,5 @@
+---
+'@portmux/cli': minor
+---
+
+Add `portmux sync` to register existing project configs into the global config, including docs and tests.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ portmux logs app web -n 200 --no-follow
 
 # Choose a registered project and start from the global config
 portmux select --all
+
+# Register an existing project config into the global config
+portmux sync
+portmux sync --all
 ```
 
 ### Command Reference
@@ -163,6 +167,7 @@ portmux select --all
 - `portmux stop [group] [process]`: Stop processes; prompts when multiple groups are running.
 - `portmux ps`: List group, process name, status, and PID.
 - `portmux select [--all]`: Pick a registered repository and run `start`; `--all` includes entries outside Git worktrees.
+- `portmux sync [--all] [--group <name>] [--name <alias>] [--dry-run] [--force] [--prune]`: Register the current project config in `~/.config/portmux/config.json`. Defaults to a single group; use `--all` to register every group.
 - `portmux logs <group> <process> [-n <lines>] [--no-follow] [-t]`: Tail logs with optional timestamps.
 
 ## Security note
@@ -189,6 +194,7 @@ portmux select --all
   - `path`: Absolute path to the project root.
   - `group`: Group name in `portmux.config.json`.
 - `portmux init` appends the current project; `start`/`restart`/`select` use this mapping for resolution.
+- `portmux sync` is the quickest way to register a repo that already ships with `portmux.config.json` (e.g., after cloning). By default it registers a single group; add `--all` to register every group, and `--prune` to drop stale entries that no longer exist on disk.
 
 ### Group Resolution
 

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { runSyncCommand } from './sync.js';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, realpathSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('runSyncCommand', () => {
+  let homeDir: string;
+  let projectDir: string;
+  let originalCwd: string;
+  let originalHome: string | undefined;
+
+  const globalConfigPath = (): string => join(homeDir, '.config', 'portmux', 'config.json');
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), 'portmux-sync-'));
+    projectDir = join(homeDir, 'repo');
+    mkdirSync(projectDir, { recursive: true });
+    originalCwd = process.cwd();
+    originalHome = process.env.HOME;
+    process.chdir(projectDir);
+    process.env.HOME = homeDir;
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    process.env.HOME = originalHome;
+    vi.restoreAllMocks();
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  function writeProjectConfig(
+    groups: Record<string, { description?: string; commands?: Record<string, string>[] }>
+  ): void {
+    writeFileSync(
+      join(projectDir, 'portmux.config.json'),
+      JSON.stringify(
+        {
+          groups,
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+  }
+
+  it('registers a single group when no global config exists', () => {
+    writeProjectConfig({
+      app: { description: 'desc', commands: [{ name: 'dev', command: 'echo dev' }] },
+    });
+
+    runSyncCommand();
+
+    const normalizedProjectDir = realpathSync(projectDir);
+    const content = JSON.parse(readFileSync(globalConfigPath(), 'utf-8'));
+    expect(content).toEqual({
+      repositories: {
+        app: { path: normalizedProjectDir, group: 'app' },
+      },
+    });
+  });
+
+  it('requires selection when multiple groups exist without flags', () => {
+    writeProjectConfig({
+      api: { description: '', commands: [{ name: 'api', command: 'echo api' }] },
+      worker: { description: '', commands: [{ name: 'worker', command: 'echo worker' }] },
+    });
+
+    runSyncCommand();
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Multiple groups found. Use --group <name> or --all to select targets.')
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(existsSync(globalConfigPath())).toBe(false);
+  });
+
+  it('registers all groups with default aliases when --all is provided', () => {
+    writeProjectConfig({
+      api: { description: '', commands: [{ name: 'api', command: 'echo api' }] },
+      worker: { description: '', commands: [{ name: 'worker', command: 'echo worker' }] },
+    });
+
+    runSyncCommand({ all: true });
+
+    const normalizedProjectDir = realpathSync(projectDir);
+    const content = JSON.parse(readFileSync(globalConfigPath(), 'utf-8'));
+    expect(content.repositories).toEqual({
+      'repo:api': { path: normalizedProjectDir, group: 'api' },
+      'repo:worker': { path: normalizedProjectDir, group: 'worker' },
+    });
+  });
+
+  it('does not write changes in dry-run mode', () => {
+    writeProjectConfig({
+      app: { description: '', commands: [{ name: 'dev', command: 'echo dev' }] },
+    });
+
+    runSyncCommand({ dryRun: true });
+
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Dry run: no changes were written.'));
+    expect(existsSync(globalConfigPath())).toBe(false);
+  });
+
+  it('prunes stale entries before writing', () => {
+    writeProjectConfig({
+      app: { description: '', commands: [{ name: 'dev', command: 'echo dev' }] },
+    });
+
+    const stalePath = join(homeDir, 'missing');
+    mkdirSync(join(homeDir, '.config', 'portmux'), { recursive: true });
+    writeFileSync(
+      globalConfigPath(),
+      JSON.stringify(
+        {
+          repositories: {
+            stale: { path: stalePath, group: 'old' },
+          },
+        },
+        null,
+        2
+      ),
+      'utf-8'
+    );
+
+    runSyncCommand({ prune: true });
+
+    const normalizedProjectDir = realpathSync(projectDir);
+    const content = JSON.parse(readFileSync(globalConfigPath(), 'utf-8'));
+    expect(content.repositories).toEqual({
+      app: { path: normalizedProjectDir, group: 'app' },
+    });
+  });
+});

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,0 +1,193 @@
+import { ConfigManager, ConfigNotFoundError, ConfigValidationError, type GlobalConfig } from '@portmux/core';
+import { Command } from 'commander';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { basename, dirname, join, resolve } from 'path';
+import { chalk } from '../lib/chalk.js';
+
+interface SyncOptions {
+  group?: string;
+  all?: boolean;
+  name?: string;
+  force?: boolean;
+  dryRun?: boolean;
+  prune?: boolean;
+}
+
+function ensureDirectory(path: string): void {
+  mkdirSync(path, { recursive: true });
+}
+
+function writeJsonFile(filePath: string, data: unknown): void {
+  ensureDirectory(dirname(filePath));
+  writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf-8');
+}
+
+function buildDefaultAlias(groupName: string, projectRoot: string, isMultiGroup: boolean): string {
+  if (!isMultiGroup) {
+    return groupName;
+  }
+  const projectName = basename(projectRoot) || 'portmux';
+  return `${projectName}:${groupName}`;
+}
+
+function selectTargetGroups(
+  projectConfigGroups: string[],
+  projectRoot: string,
+  options: SyncOptions
+): { alias: string; group: string }[] {
+  const isMultiGroup = projectConfigGroups.length > 1;
+
+  if (options.name && options.all) {
+    throw new Error('The --name option cannot be used together with --all.');
+  }
+
+  if (options.all) {
+    return projectConfigGroups.map((group) => ({
+      alias: buildDefaultAlias(group, projectRoot, true),
+      group,
+    }));
+  }
+
+  const targetGroup = options.group ?? (projectConfigGroups.length === 1 ? projectConfigGroups[0] : null);
+  if (!targetGroup) {
+    throw new Error('Multiple groups found. Use --group <name> or --all to select targets.');
+  }
+
+  return [
+    {
+      alias: options.name ?? buildDefaultAlias(targetGroup, projectRoot, isMultiGroup),
+      group: targetGroup,
+    },
+  ];
+}
+
+function pruneGlobalConfig(globalConfig: GlobalConfig): string[] {
+  const removed: string[] = [];
+  const keptEntries = Object.entries(globalConfig.repositories).filter(([alias, repository]) => {
+    const configPath = join(repository.path, 'portmux.config.json');
+    const shouldKeep = existsSync(repository.path) && existsSync(configPath);
+    if (!shouldKeep) {
+      removed.push(alias);
+    }
+    return shouldKeep;
+  });
+
+  globalConfig.repositories = Object.fromEntries(keptEntries);
+  return removed;
+}
+
+export function runSyncCommand(options: SyncOptions = {}): void {
+  try {
+    const projectConfigPath = ConfigManager.findConfigFile();
+    const projectConfig = ConfigManager.loadConfig(projectConfigPath);
+    const projectRoot = resolve(dirname(projectConfigPath));
+
+    const groupNames = Object.keys(projectConfig.groups);
+    if (groupNames.length === 0) {
+      console.error(chalk.red('Error: No groups are defined in portmux.config.json.'));
+      process.exit(1);
+      return;
+    }
+
+    let targets: { alias: string; group: string }[];
+    try {
+      targets = selectTargetGroups(groupNames, projectRoot, options);
+    } catch (error) {
+      console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
+      process.exit(1);
+      return;
+    }
+
+    const globalConfigPath = ConfigManager.getGlobalConfigPath();
+    const globalConfig: GlobalConfig = ConfigManager.loadGlobalConfig() ?? { repositories: {} };
+
+    let pruned: string[] = [];
+    if (options.prune) {
+      pruned = pruneGlobalConfig(globalConfig);
+    }
+
+    const updates: string[] = [];
+    const skipped: string[] = [];
+
+    for (const target of targets) {
+      const existing = globalConfig.repositories[target.alias];
+      if (existing) {
+        if (existing.path === projectRoot && existing.group === target.group) {
+          skipped.push(`Unchanged: ${target.alias} (${target.group})`);
+          continue;
+        }
+
+        if (!options.force) {
+          skipped.push(
+            `Skipped existing entry "${target.alias}". Use --force to overwrite or choose a different --name.`
+          );
+          continue;
+        }
+      }
+
+      globalConfig.repositories[target.alias] = {
+        path: projectRoot,
+        group: target.group,
+      };
+
+      updates.push(`${existing ? 'Updated' : 'Added'}: ${target.alias} (${target.group}) -> ${projectRoot}`);
+    }
+
+    ConfigManager.validateGlobalConfig(globalConfig, projectConfig, projectConfigPath);
+
+    if (options.dryRun) {
+      console.log(chalk.yellow('Dry run: no changes were written.'));
+      if (pruned.length > 0) {
+        console.log(chalk.yellow(`Would prune: ${pruned.join(', ')}`));
+      }
+      if (updates.length > 0) {
+        console.log(chalk.green(`Would apply: ${updates.join('; ')}`));
+      }
+      if (skipped.length > 0) {
+        console.log(chalk.yellow(skipped.join('; ')));
+      }
+      return;
+    }
+
+    writeJsonFile(globalConfigPath, globalConfig);
+
+    if (pruned.length > 0) {
+      console.log(chalk.yellow(`Pruned entries: ${pruned.join(', ')}`));
+    }
+    for (const line of updates) {
+      console.log(chalk.green(`✓ ${line}`));
+    }
+    for (const line of skipped) {
+      console.log(chalk.yellow(line));
+    }
+
+    if (updates.length === 0 && pruned.length === 0) {
+      console.log(chalk.yellow('No changes were made.'));
+    }
+  } catch (error) {
+    if (error instanceof ConfigNotFoundError || error instanceof ConfigValidationError) {
+      console.error(chalk.red(`Error: ${error.message}`));
+      process.exit(1);
+      return;
+    }
+
+    console.error(chalk.red(`Error: ${error instanceof Error ? error.message : String(error)}`));
+    process.exit(1);
+  }
+}
+
+function createSyncCommand(): Command {
+  return new Command('sync')
+    .description('Register the current project in the global config')
+    .option('--group <name>', 'Group to register (defaults to the first when only one exists)')
+    .option('--all', 'Register all groups defined in the project config')
+    .option('--name <alias>', 'Repository alias to use in the global config (single group only)')
+    .option('--force', 'Overwrite existing entries with the same alias')
+    .option('--dry-run', 'Show what would change without writing the global config')
+    .option('--prune', 'Remove global entries whose paths or configs no longer exist')
+    .action((options: SyncOptions) => {
+      runSyncCommand(options);
+    });
+}
+
+export const syncCommand: ReturnType<typeof createSyncCommand> = createSyncCommand();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import { selectCommand } from './commands/select.js';
 import { initCommand } from './commands/init.js';
 import { restartCommand } from './commands/restart.js';
 import { logsCommand } from './commands/logs.js';
+import { syncCommand } from './commands/sync.js';
 
 const program = new Command();
 
@@ -24,6 +25,7 @@ program.addCommand(stopCommand);
 program.addCommand(restartCommand);
 program.addCommand(psCommand);
 program.addCommand(selectCommand);
+program.addCommand(syncCommand);
 program.addCommand(logsCommand);
 
 // Global error handler


### PR DESCRIPTION
Adds the `portmux sync` command to register existing project configurations into the global configuration, simplifying the process of adding new projects, especially after cloning.

Includes options for selecting specific groups, registering all groups, and handling existing entries, improving user experience when dealing with multiple project configurations.

Adds tests to verify the command's behavior.