### PR TITLE
Restarts all groups on worktree select

### DIFF
--- a/.changeset/restart-all-groups.md
+++ b/.changeset/restart-all-groups.md
@@ -1,0 +1,5 @@
+---
+'@portmux/cli': patch
+---
+
+Ensure `portmux select` stops other worktrees for the same repository and restarts every running group definition in the newly selected worktree.

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -19,6 +19,7 @@ import { buildGroupInstanceId, buildGroupLabel } from '../utils/group-instance.j
 interface StartInvokeOptions {
   worktreePath?: string;
   worktreeLabel?: string;
+  groupDefinitionNameOverride?: string;
 }
 
 function extractCauseMessage(cause: unknown): string | undefined {
@@ -119,7 +120,7 @@ export async function runStartCommand(
       }
     }
 
-    const targetGroup = resolvedGroup.groupDefinitionName;
+    const targetGroup = invokeOptions?.groupDefinitionNameOverride ?? resolvedGroup.groupDefinitionName;
     const group = resolvedGroup.projectConfig.groups[targetGroup];
     const projectRoot = resolvedGroup.path;
 

--- a/portmux.config.json
+++ b/portmux.config.json
@@ -5,7 +5,16 @@
       "description": "",
       "commands": [
         {
-          "name": "sleep",
+          "name": "sleep1",
+          "command": "sleep 1000"
+        }
+      ]
+    },
+    "debug2": {
+      "description": "",
+      "commands": [
+        {
+          "name": "sleep2",
           "command": "sleep 1000"
         }
       ]


### PR DESCRIPTION
Ensures that `portmux select` stops all running processes associated with other worktrees of the same repository. It then restarts every group definition in the newly selected worktree, maintaining the intended environment state.