### PR TITLE
Adds --all flag to stop all running groups

### DIFF
--- a/.changeset/stop-all-groups.md
+++ b/.changeset/stop-all-groups.md
@@ -1,0 +1,5 @@
+---
+'@portmux/cli': minor
+---
+
+Add `stop --all` to stop every running group without specifying a group name when multiple groups are active.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ portmux start app web
 # Restart or stop
 portmux restart app web
 portmux stop app
+# When multiple groups are running and you want to stop everything at once
+portmux stop --all
 
 # Show running state for all worktrees
 portmux ps

--- a/packages/cli/src/commands/stop.test.ts
+++ b/packages/cli/src/commands/stop.test.ts
@@ -80,6 +80,20 @@ describe('stopCommand', () => {
     expect(console.log).toHaveBeenCalledWith('✓ Stopped process "worker" (ws1)');
   });
 
+  it('stops all running groups when --all is provided', async () => {
+    listAllStates.mockReturnValue([
+      { group: 'ws1', process: 'api', status: 'Running' as const },
+      { group: 'ws2', process: 'worker', status: 'Running' as const },
+    ]);
+
+    await runStopCommand(undefined, undefined, { stopAll: true });
+
+    expect(process.exit).not.toHaveBeenCalled();
+    expect(ProcessManager.stopProcess).toHaveBeenCalledTimes(2);
+    expect(LockManager.withLock).toHaveBeenCalledWith('group', 'ws1', expect.any(Function));
+    expect(LockManager.withLock).toHaveBeenCalledWith('group', 'ws2', expect.any(Function));
+  });
+
   it('passes timeout option to stopProcess', async () => {
     listAllStates.mockReturnValue([{ group: 'ws1', process: 'api', status: 'Running' as const }]);
 


### PR DESCRIPTION
Adds the ability to stop all running groups without specifying a group name when multiple groups are active, using the `--all` flag.

This provides a convenient way to shut down all running portmux instances at once.