### PR TITLE
Adds sync guidance to error messages

### DIFF
--- a/.changeset/register-sync-hint.md
+++ b/.changeset/register-sync-hint.md
@@ -1,0 +1,6 @@
+---
+'@portmux/core': patch
+'@portmux/cli': patch
+---
+
+Add sync guidance when the global config is missing and highlight `portmux sync --all` for multi-group projects.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ PortMux is built on a few core principles to streamline the developer experience
 
 ## Quick Start
 
-1. `portmux init` in your project root to generate `portmux.config.json` and register the repo in `~/.config/portmux/config.json` (use `--force` to overwrite).
-2. Edit the generated config. Example:
+1. `portmux init` in your project root to generate `portmux.config.json` and register the repo in `~/.config/portmux/config.json` (use `--force` to overwrite). If your repo already includes `portmux.config.json` (e.g., after cloning), run `portmux sync --all` for monorepos or any project with multiple groups to register everything without prompts.
+2. Edit the generated config (or review the existing one) and keep your group definitions up to date. Example:
    ```json
    {
      "$schema": "node_modules/@portmux/cli/schemas/portmux.config.schema.json",
@@ -72,9 +72,10 @@ PortMux is built on a few core principles to streamline the developer experience
      }
    }
    ```
-3. Start everything with `portmux start`.
-4. Inspect running processes with `portmux ps`.
-5. Follow logs with `portmux logs <group> <process>` and stop with `portmux stop [group] [process]`.
+3. Ensure the repository is registered in the global config with `portmux sync` (prefer `--all` for monorepos or when multiple groups exist).
+4. Start everything with `portmux start`.
+5. Inspect running processes with `portmux ps`.
+6. Follow logs with `portmux logs <group> <process>` and stop with `portmux stop [group] [process]`.
 
 ## Usage Examples
 

--- a/packages/core/src/group/group-manager.ts
+++ b/packages/core/src/group/group-manager.ts
@@ -195,13 +195,17 @@ export const GroupManager = {
     if (!merged) {
       throw new GroupResolutionError(
         `Repository "${repositoryName}" was not found.\n` +
-          `The global config file (${ConfigManager.getGlobalConfigPath()}) does not exist.`
+          `The global config file (${ConfigManager.getGlobalConfigPath()}) does not exist.\n` +
+          `Run "portmux sync" in your project to register this repository.`
       );
     }
 
     const mergedRepository = merged.repositories[repositoryName];
     if (!mergedRepository) {
-      throw new GroupResolutionError(`Repository "${repositoryName}" was not found in the global config.`);
+      throw new GroupResolutionError(
+        `Repository "${repositoryName}" was not found in the global config.\n` +
+          `Run "portmux sync" in your project to register this repository.`
+      );
     }
 
     let projectConfig = mergedRepository.projectConfig;
@@ -349,7 +353,8 @@ export const GroupManager = {
     throw new GroupResolutionError(
       `The repository for this git worktree is not defined in the global config.\n` +
         `Worktree path: ${matchedWorktreePath}\n` +
-        `Add the repository to the global config file: ${ConfigManager.getGlobalConfigPath()}`
+        `Add the repository to the global config file: ${ConfigManager.getGlobalConfigPath()}\n` +
+        `Run "portmux sync" in your project to register this repository.`
     );
   },
 


### PR DESCRIPTION
Improves the developer experience by adding helpful hints to error messages, suggesting the use of `portmux sync` to resolve configuration issues, especially when the global config is missing.  Also updates the README to emphasize the `portmux sync --all` command for monorepos.