### PR TITLE
Ensures only selected group starts

### DIFF
--- a/.changeset/start-selected-group.md
+++ b/.changeset/start-selected-group.md
@@ -1,0 +1,5 @@
+---
+'@portmux/cli': patch
+---
+
+Ensure `portmux select` only starts the chosen group when no other worktrees are running.

--- a/packages/cli/src/commands/select.test.ts
+++ b/packages/cli/src/commands/select.test.ts
@@ -187,6 +187,50 @@ describe('selectCommand', () => {
     expect(runStopMock).not.toHaveBeenCalled();
   });
 
+  it('starts only the selected group definition when none are running', async () => {
+    buildSelectableGroups.mockReturnValue([
+      {
+        projectName: 'proj',
+        repositoryName: 'repo1',
+        repositoryPath: '/path/repo1',
+        worktreePath: '/path/repo1',
+        isRunning: false,
+        groupDefinitionName: 'app1',
+        hasConfig: true,
+        isPrimary: true,
+      },
+    ]);
+    resolveGroupByName.mockReturnValue({
+      name: 'repo1',
+      path: '/path/repo1',
+      projectConfig: {
+        groups: {
+          app1: { description: '', commands: [] },
+          app2: { description: '', commands: [] },
+        },
+      },
+      projectConfigPath: '/path/repo1/portmux.config.json',
+      groupDefinitionName: 'app1',
+    });
+    promptMock.mockResolvedValue({
+      group: {
+        repositoryName: 'repo1',
+        worktreePath: '/path/repo1',
+        branchLabel: undefined,
+        repositoryPath: '/path/repo1',
+      },
+    });
+
+    await runSelect();
+
+    expect(runStartMock).toHaveBeenCalledTimes(1);
+    expect(runStartMock).toHaveBeenCalledWith('repo1', undefined, {
+      worktreePath: '/path/repo1',
+      worktreeLabel: undefined,
+      groupDefinitionNameOverride: 'app1',
+    });
+  });
+
   it('stops running processes in other worktrees before starting selected group', async () => {
     buildSelectableGroups.mockReturnValue([
       {

--- a/packages/cli/src/commands/select.ts
+++ b/packages/cli/src/commands/select.ts
@@ -149,8 +149,7 @@ function createSelectCommand(): Command {
           }
         }
 
-        const availableGroups = Object.keys(resolved.projectConfig.groups);
-        const targetGroups = groupsToRestart.size > 0 ? Array.from(groupsToRestart) : availableGroups;
+        const targetGroups = groupsToRestart.size > 0 ? Array.from(groupsToRestart) : [resolved.groupDefinitionName];
 
         if (targetGroups.length === 0) {
           console.log(chalk.yellow('No groups defined in project config.'));


### PR DESCRIPTION
Ensures that when using `portmux select`, only the chosen group is started if no other worktrees
are currently running.

This prevents unintended behavior where all groups in the project would be started instead of just the selected one.