### PR TITLE
Adds --all flag to start and restart commands

### DIFF
--- a/.changeset/start-restart-all.md
+++ b/.changeset/start-restart-all.md
@@ -1,0 +1,5 @@
+---
+'@portmux/cli': minor
+---
+
+Add `--all` option to `start` to launch every group in the project config and to `restart` to restart all running processes in the current worktree.

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ portmux sync --all
 ### Command Reference
 
 - `portmux init [--force]`: Interactive setup for `portmux.config.json` and global registration.
-- `portmux start [group] [process]`: Start processes with port reservation and env substitution.
-- `portmux restart [group] [process]`: Stop then start using the same resolution rules as `start`.
+- `portmux start [group] [process] [--all]`: Start processes with port reservation and env substitution. `--all` starts every group defined in the project config for the current worktree.
+- `portmux restart [group] [process] [--all]`: Stop then start using the same resolution rules as `start`. `--all` restarts every running process in the current worktree.
 - `portmux stop [group] [process] [--all] [-t, --timeout <ms>]`: Stop processes; errors when multiple groups are running unless `--all`, and `--timeout` controls the wait before SIGKILL (default: 3000 ms).
 - `portmux ps`: List group, process name, status, and PID.
 - `portmux select [--all]`: Pick a registered repository and run `start`; `--all` includes entries outside Git worktrees.


### PR DESCRIPTION
Adds the `--all` option to the `start` and `restart` commands.

This enhancement allows users to start every group defined in the project config with the `start` command and restart all running processes in the current worktree using the `restart` command.