### PR TITLE
Shortens paths to home directory in CLI outputs

### DIFF
--- a/.changeset/shorten-home-path-display.md
+++ b/.changeset/shorten-home-path-display.md
@@ -1,0 +1,5 @@
+---
+'@portmux/cli': patch
+---
+
+Shorten home directory paths to `~` in CLI outputs

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -1,6 +1,7 @@
 import { StateManager, type ProcessState, getLogDir } from '@portmux/core';
 import { Command } from 'commander';
 import { chalk } from '../lib/chalk.js';
+import { shortenHomePath } from '../utils/path-label.js';
 import { createReadStream, existsSync, lstatSync, readFileSync, statSync, watch } from 'fs';
 import { resolve, sep } from 'path';
 
@@ -65,7 +66,7 @@ function formatStateLabel(state: ProcessState): string {
   const label = state.groupLabel ?? state.repositoryName ?? state.group;
   const path = state.worktreePath ?? state.groupKey;
   if (path) {
-    return `${label} (${path})`;
+    return `${label} (${shortenHomePath(path)})`;
   }
   return label;
 }

--- a/packages/cli/src/commands/ps.ts
+++ b/packages/cli/src/commands/ps.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { ProcessManager } from '@portmux/core';
 import { chalk } from '../lib/chalk.js';
+import { shortenHomePath } from '../utils/path-label.js';
 
 export const psCommand: ReturnType<typeof createPsCommand> = createPsCommand();
 
@@ -8,7 +9,7 @@ function formatRepositoryLabel(process: ReturnType<typeof ProcessManager.listPro
   const label = process.groupLabel ?? process.repositoryName ?? process.group;
   const path = process.worktreePath ?? process.groupKey;
   if (path) {
-    return `${label} (${path})`;
+    return `${label} (${shortenHomePath(path)})`;
   }
   return label;
 }

--- a/packages/cli/src/commands/select.ts
+++ b/packages/cli/src/commands/select.ts
@@ -1,6 +1,7 @@
 import { GroupManager, StateManager, type GroupSelection } from '@portmux/core';
 import { Command } from 'commander';
 import { chalk } from '../lib/chalk.js';
+import { shortenHomePath } from '../utils/path-label.js';
 import inquirer, { type ChoiceCollection } from 'inquirer';
 import { runStartCommand } from './start.js';
 import { runStopCommand } from './stop.js';
@@ -46,8 +47,9 @@ function buildChoices(selections: GroupSelection[]): ChoiceCollection<GroupAnswe
     const runningLabel = selection.isRunning ? '[Running] ' : '';
     const branchLabel = selection.branchLabel ? `:${selection.branchLabel}` : '';
     const configSuffix = selection.hasConfig ? '' : ' [Missing config]';
+    const displayPath = shortenHomePath(selection.worktreePath);
     const choice = {
-      name: `${runningLabel}${selection.repositoryName}${branchLabel} (${selection.worktreePath})${configSuffix}`,
+      name: `${runningLabel}${selection.repositoryName}${branchLabel} (${displayPath})${configSuffix}`,
       short: `${selection.repositoryName}${branchLabel}`,
       value: {
         repositoryName: selection.repositoryName,
@@ -101,7 +103,7 @@ function findRunningWorktrees(repositoryName: string, targetWorktreePath: string
 }
 
 function formatRunningWorktreeLabel(worktree: RunningWorktree): string {
-  const pathLabel = worktree.worktreePath ?? 'unknown worktree';
+  const pathLabel = worktree.worktreePath ? shortenHomePath(worktree.worktreePath) : 'unknown worktree';
   if (worktree.branch) {
     return `${pathLabel} [${worktree.branch}]`;
   }

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -9,6 +9,7 @@ import {
 
 import { Command } from 'commander';
 import { chalk } from '../lib/chalk.js';
+import { shortenHomePath } from '../utils/path-label.js';
 
 export const stopCommand: ReturnType<typeof createStopCommand> = createStopCommand();
 
@@ -21,7 +22,7 @@ function formatStateLabel(state: ProcessState): string {
   const label = state.groupLabel ?? state.repositoryName ?? state.group;
   const path = state.worktreePath ?? state.groupKey;
   if (path) {
-    return `${label} (${path})`;
+    return `${label} (${shortenHomePath(path)})`;
   }
   return label;
 }

--- a/packages/cli/src/utils/path-label.test.ts
+++ b/packages/cli/src/utils/path-label.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { homedir } from 'os';
+import { join, sep } from 'path';
+import { shortenHomePath } from './path-label.js';
+
+describe('shortenHomePath', () => {
+  it('replaces the home prefix with tilde for nested paths', () => {
+    const home = homedir();
+    const nestedPath = join(home, 'projects', 'app');
+    expect(shortenHomePath(nestedPath)).toBe(`~${nestedPath.slice(home.length)}`);
+  });
+
+  it('returns tilde for the home directory itself', () => {
+    const home = homedir();
+    expect(shortenHomePath(home)).toBe('~');
+  });
+
+  it('returns the original path when outside the home', () => {
+    const outsidePath = join(sep, 'var', 'app');
+    expect(shortenHomePath(outsidePath)).toBe(outsidePath);
+  });
+});

--- a/packages/cli/src/utils/path-label.ts
+++ b/packages/cli/src/utils/path-label.ts
@@ -1,0 +1,24 @@
+import { homedir } from 'os';
+import { sep } from 'path';
+
+/**
+ * Replace the user's home directory prefix with ~ for display.
+ */
+export function shortenHomePath(path: string): string {
+  const home = homedir();
+  if (!home) {
+    return path;
+  }
+
+  const homeWithSep = home.endsWith(sep) ? home : `${home}${sep}`;
+
+  if (path === home) {
+    return '~';
+  }
+
+  if (path.startsWith(homeWithSep)) {
+    return `~${path.slice(home.length)}`;
+  }
+
+  return path;
+}


### PR DESCRIPTION
Replaces the user's home directory prefix with `~` for display in CLI outputs.

This change enhances readability and reduces verbosity in console logs, especially when dealing with paths within the user's home directory. Affected commands include `logs`, `ps`, `select`, and `stop`.