### PR TITLE
Adds configurable log size trimming

### DIFF
--- a/.changeset/trim-log-size.md
+++ b/.changeset/trim-log-size.md
@@ -1,0 +1,6 @@
+---
+'@portmux/core': minor
+'@portmux/cli': minor
+---
+
+Add configurable log size cap (default 10MB) with automatic trimming to keep the newest output.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ PortMux is built on a few core principles to streamline the developer experience
    ```json
    {
      "$schema": "node_modules/@portmux/cli/schemas/portmux.config.schema.json",
+     "logs": {
+       "maxBytes": 10485760
+     },
      "groups": {
        "app": {
          "description": "Demo group",
@@ -207,6 +210,7 @@ portmux sync --all
 
 - `stdout`/`stderr` are written to `~/.config/portmux/logs/`; view with `portmux logs`.
 - Process state, PIDs, and reserved ports persist in `~/.config/portmux/` for reuse by `ps` and `logs`.
+- Log files are automatically trimmed to the newest content when they exceed 10MB by default; override per project via `logs.maxBytes` in `portmux.config.json`.
 - Log cleanup: `portmux stop` removes the associated log file, and `portmux ps` prunes log files not referenced by any recorded process state. No separate prune command is required.
 
 ## Development

--- a/packages/cli/schemas/portmux.config.schema.json
+++ b/packages/cli/schemas/portmux.config.schema.json
@@ -12,6 +12,9 @@
     "runner": {
       "$ref": "#/$defs/runner"
     },
+    "logs": {
+      "$ref": "#/$defs/logs"
+    },
     "groups": {
       "type": "object",
       "minProperties": 1,
@@ -37,6 +40,17 @@
         }
       },
       "required": ["mode"]
+    },
+    "logs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxBytes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum log file size in bytes before trimming keeps the newest content."
+        }
+      }
     },
     "group": {
       "type": "object",

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -84,6 +84,7 @@ async function restartProcessesForGroup(
   }
 
   const processes = processNames ? groupDef.commands.filter((cmd) => processNames.has(cmd.name)) : groupDef.commands;
+  const logMaxBytes = resolvedGroup.projectConfig.logs?.maxBytes;
 
   if (processes.length === 0) {
     const label = processNames?.size === 1 ? Array.from(processNames)[0] : undefined;
@@ -112,6 +113,7 @@ async function restartProcessesForGroup(
           groupDefinitionName: targetGroup,
           worktreePath: resolvedGroup.path,
           ...(cmd.ports !== undefined && { ports: cmd.ports }),
+          ...(logMaxBytes !== undefined && { logMaxBytes }),
         });
 
         console.log(chalk.green(`✓ Restarted process "${cmd.name}"`));

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -101,6 +101,7 @@ export async function runStartCommand(
     }
 
     const projectRoot = resolvedGroup.path;
+    const logMaxBytes = resolvedGroup.projectConfig.logs?.maxBytes;
     if (invokeOptions?.startAll && processName) {
       console.error(chalk.red('Error: --all cannot be combined with a process name'));
       process.exit(1);
@@ -156,6 +157,7 @@ export async function runStartCommand(
               worktreePath: projectRoot,
               ...(invokeOptions?.worktreeLabel !== undefined && { branch: invokeOptions.worktreeLabel }),
               ...(cmd.ports !== undefined && { ports: cmd.ports }),
+              ...(logMaxBytes !== undefined && { logMaxBytes }),
             });
 
             console.log(chalk.green(`✓ Started process "${cmd.name}"`));

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -34,6 +34,11 @@ export const RunnerSchema = z.object({
   mode: z.literal('background'),
 });
 
+/** Logs configuration schema. */
+export const LogsConfigSchema = z.object({
+  maxBytes: z.number().int().positive().optional(),
+});
+
 /**
  * Project-level PortMux configuration schema.
  */
@@ -41,6 +46,7 @@ export const PortMuxConfigSchema = z
   .object({
     $schema: z.string().optional(),
     runner: RunnerSchema.optional(),
+    logs: LogsConfigSchema.optional(),
     groups: z.record(z.string(), GroupSchema),
   })
   .refine((data) => Object.keys(data.groups).length > 0, {
@@ -68,5 +74,6 @@ export const GlobalConfigSchema = z.object({
 export type PortMuxConfig = z.infer<typeof PortMuxConfigSchema>;
 export type Group = z.infer<typeof GroupSchema>;
 export type Command = z.infer<typeof CommandSchema>;
+export type LogsConfig = z.infer<typeof LogsConfigSchema>;
 export type GlobalConfig = z.infer<typeof GlobalConfigSchema>;
 export type Repository = z.infer<typeof RepositorySchema>;

--- a/packages/core/src/log/log-writer.test.ts
+++ b/packages/core/src/log/log-writer.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { LogWriter } from './log-writer.js';
+
+describe('LogWriter', () => {
+  it('trims the log when exceeding the max size while preserving the tail', async () => {
+    const testTmpDir = mkdtempSync(join(tmpdir(), 'portmux-log-writer-'));
+    const logPath = join(testTmpDir, 'log.log');
+    const writer = await LogWriter.create(logPath, 100, 0.5);
+
+    await writer.write('a'.repeat(80));
+    await writer.write('b'.repeat(80));
+    await writer.close();
+
+    const content = readFileSync(logPath, 'utf-8');
+    expect(content).toBe('b'.repeat(50));
+
+    rmSync(testTmpDir, { recursive: true, force: true });
+  });
+});

--- a/packages/core/src/log/log-writer.ts
+++ b/packages/core/src/log/log-writer.ts
@@ -1,0 +1,129 @@
+import { createWriteStream, type WriteStream } from 'fs';
+import { open, stat, writeFile, type FileHandle } from 'fs/promises';
+import { PortmuxError } from '../errors.js';
+
+const DEFAULT_KEEP_RATIO = 0.8;
+
+export class LogWriteError extends PortmuxError {
+  override readonly name = 'LogWriteError';
+}
+
+export class LogWriter {
+  private constructor(
+    private readonly logPath: string,
+    private readonly maxBytes: number,
+    private readonly keepBytes: number,
+    private writeStream: WriteStream,
+    private currentSize: number,
+    private pending: Promise<void>
+  ) {}
+
+  static async create(logPath: string, maxBytes: number, keepRatio: number = DEFAULT_KEEP_RATIO): Promise<LogWriter> {
+    if (maxBytes <= 0) {
+      throw new LogWriteError(`maxBytes must be positive. Received: ${String(maxBytes)}`);
+    }
+
+    if (keepRatio <= 0 || keepRatio >= 1) {
+      throw new LogWriteError(`keepRatio must be between 0 and 1. Received: ${String(keepRatio)}`);
+    }
+
+    const keepBytes = Math.max(1, Math.floor(maxBytes * keepRatio));
+    const existingSize = await LogWriter.getFileSize(logPath);
+    const writeStream = createWriteStream(logPath, { flags: 'a', mode: 0o600 });
+
+    return new LogWriter(logPath, maxBytes, keepBytes, writeStream, existingSize, Promise.resolve());
+  }
+
+  private static async getFileSize(path: string): Promise<number> {
+    try {
+      const stats = await stat(path);
+      return stats.size;
+    } catch {
+      return 0;
+    }
+  }
+
+  async write(chunk: Buffer | string): Promise<void> {
+    const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.pending = this.pending.catch(() => undefined).then(() => this.appendAndTrim(data));
+    return this.pending;
+  }
+
+  async close(): Promise<void> {
+    this.pending = this.pending.catch(() => undefined).then(() => this.closeStream());
+    return this.pending;
+  }
+
+  private async appendAndTrim(data: Buffer): Promise<void> {
+    await this.writeToStream(data);
+    this.currentSize += data.length;
+
+    if (this.currentSize > this.maxBytes) {
+      await this.trim();
+    }
+  }
+
+  private async closeStream(): Promise<void> {
+    if (this.writeStream.closed) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      this.writeStream.end((error: NodeJS.ErrnoException | null) => {
+        if (error) {
+          reject(new LogWriteError(`Failed to close log file: ${this.logPath}`, error));
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  private async trim(): Promise<void> {
+    // Close the current stream before rewriting the file
+    await this.closeStream();
+
+    const keepBytes = Math.min(this.keepBytes, this.maxBytes);
+    let retained = Buffer.alloc(0);
+    let handle: FileHandle | null = null;
+
+    // Read the tail of the file to retain the most recent content
+    try {
+      handle = await open(this.logPath, 'r');
+    } catch {
+      handle = null;
+    }
+
+    if (handle !== null) {
+      try {
+        const stats = await handle.stat();
+        const bytesToKeep = Math.min(keepBytes, stats.size);
+        retained = Buffer.alloc(bytesToKeep);
+        if (bytesToKeep > 0) {
+          await handle.read(retained, 0, bytesToKeep, stats.size - bytesToKeep);
+        }
+      } finally {
+        await handle.close();
+      }
+    }
+
+    // Rewrite the file with the retained content
+    await writeFile(this.logPath, retained, { mode: 0o600 });
+    this.currentSize = retained.length;
+
+    // Reopen the stream in append mode
+    this.writeStream = createWriteStream(this.logPath, { flags: 'a', mode: 0o600 });
+  }
+
+  private async writeToStream(data: Buffer): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.writeStream.write(data, (error) => {
+        if (error) {
+          reject(new LogWriteError(`Failed to write to log file: ${this.logPath}`, error));
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}

--- a/portmux.config.json
+++ b/portmux.config.json
@@ -1,5 +1,8 @@
 {
-  "$schema": "node_modules/@portmux/cli/schemas/portmux.config.schema.json",
+  "$schema": "~/.bun/install/global/node_modules/@portmux/cli/schemas/portmux.config.schema.json",
+  "logs": {
+    "maxBytes": 10485760
+  },
   "groups": {
     "app1": {
       "description": "",


### PR DESCRIPTION
Introduces a configurable maximum log file size.

When logs exceed the configured `maxBytes` limit (defaulting to 10MB), the log file is trimmed to retain only the newest content, preventing unbounded disk usage. This functionality is configurable at the project level via `portmux.config.json`.