### PR TITLE
Fixes hanging issue with direct FD logs

### DIFF
--- a/.changeset/direct-fd-log-trim.md
+++ b/.changeset/direct-fd-log-trim.md
@@ -1,0 +1,6 @@
+---
+'@portmux/core': patch
+'@portmux/cli': patch
+---
+
+Write process logs directly to file descriptors again and trim at boundaries to avoid `portmux select` hanging from open stdout/stderr pipes.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ portmux sync --all
 - `stdout`/`stderr` are written to `~/.config/portmux/logs/`; view with `portmux logs`.
 - Process state, PIDs, and reserved ports persist in `~/.config/portmux/` for reuse by `ps` and `logs`.
 - Log files are automatically trimmed to the newest content when they exceed 10MB by default; override per project via `logs.maxBytes` in `portmux.config.json`.
+- Trimming runs at process start and when listing processes (`portmux ps`), keeping only the tail within the configured limit.
 - Log cleanup: `portmux stop` removes the associated log file, and `portmux ps` prunes log files not referenced by any recorded process state. No separate prune command is required.
 
 ## Development

--- a/packages/core/src/log/log-writer.test.ts
+++ b/packages/core/src/log/log-writer.test.ts
@@ -1,21 +1,32 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { LogWriter } from './log-writer.js';
+import { trimLogFile, trimLogFileSync } from './log-writer.js';
 
 describe('LogWriter', () => {
-  it('trims the log when exceeding the max size while preserving the tail', async () => {
+  it('trims the log when exceeding the max size while preserving the tail (async)', async () => {
     const testTmpDir = mkdtempSync(join(tmpdir(), 'portmux-log-writer-'));
     const logPath = join(testTmpDir, 'log.log');
-    const writer = await LogWriter.create(logPath, 100, 0.5);
 
-    await writer.write('a'.repeat(80));
-    await writer.write('b'.repeat(80));
-    await writer.close();
+    writeFileSync(logPath, 'a'.repeat(80) + 'b'.repeat(80));
+    await trimLogFile(logPath, 100, 0.5);
 
     const content = readFileSync(logPath, 'utf-8');
     expect(content).toBe('b'.repeat(50));
+
+    rmSync(testTmpDir, { recursive: true, force: true });
+  });
+
+  it('trims the log synchronously when exceeding the max size', () => {
+    const testTmpDir = mkdtempSync(join(tmpdir(), 'portmux-log-writer-'));
+    const logPath = join(testTmpDir, 'log.log');
+
+    writeFileSync(logPath, 'x'.repeat(30));
+    trimLogFileSync(logPath, 20, 0.5);
+
+    const content = readFileSync(logPath, 'utf-8');
+    expect(content).toBe('x'.repeat(10));
 
     rmSync(testTmpDir, { recursive: true, force: true });
   });

--- a/packages/core/src/log/log-writer.ts
+++ b/packages/core/src/log/log-writer.ts
@@ -1,5 +1,5 @@
-import { createWriteStream, type WriteStream } from 'fs';
-import { open, stat, writeFile, type FileHandle } from 'fs/promises';
+import { closeSync, openSync, readSync, statSync, writeFileSync } from 'fs';
+import { open, writeFile, type FileHandle } from 'fs/promises';
 import { PortmuxError } from '../errors.js';
 
 const DEFAULT_KEEP_RATIO = 0.8;
@@ -8,122 +8,77 @@ export class LogWriteError extends PortmuxError {
   override readonly name = 'LogWriteError';
 }
 
-export class LogWriter {
-  private constructor(
-    private readonly logPath: string,
-    private readonly maxBytes: number,
-    private readonly keepBytes: number,
-    private writeStream: WriteStream,
-    private currentSize: number,
-    private pending: Promise<void>
-  ) {}
-
-  static async create(logPath: string, maxBytes: number, keepRatio: number = DEFAULT_KEEP_RATIO): Promise<LogWriter> {
-    if (maxBytes <= 0) {
-      throw new LogWriteError(`maxBytes must be positive. Received: ${String(maxBytes)}`);
-    }
-
-    if (keepRatio <= 0 || keepRatio >= 1) {
-      throw new LogWriteError(`keepRatio must be between 0 and 1. Received: ${String(keepRatio)}`);
-    }
-
-    const keepBytes = Math.max(1, Math.floor(maxBytes * keepRatio));
-    const existingSize = await LogWriter.getFileSize(logPath);
-    const writeStream = createWriteStream(logPath, { flags: 'a', mode: 0o600 });
-
-    return new LogWriter(logPath, maxBytes, keepBytes, writeStream, existingSize, Promise.resolve());
+export async function trimLogFile(
+  logPath: string,
+  maxBytes: number,
+  keepRatio: number = DEFAULT_KEEP_RATIO
+): Promise<void> {
+  if (maxBytes <= 0) {
+    throw new LogWriteError(`maxBytes must be positive. Received: ${String(maxBytes)}`);
   }
 
-  private static async getFileSize(path: string): Promise<number> {
-    try {
-      const stats = await stat(path);
-      return stats.size;
-    } catch {
-      return 0;
-    }
+  if (keepRatio <= 0 || keepRatio >= 1) {
+    throw new LogWriteError(`keepRatio must be between 0 and 1. Received: ${String(keepRatio)}`);
   }
 
-  async write(chunk: Buffer | string): Promise<void> {
-    const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    this.pending = this.pending.catch(() => undefined).then(() => this.appendAndTrim(data));
-    return this.pending;
+  const keepBytes = Math.max(1, Math.floor(maxBytes * keepRatio));
+  let handle: FileHandle | null = null;
+
+  try {
+    handle = await open(logPath, 'r');
+  } catch {
+    return;
   }
 
-  async close(): Promise<void> {
-    this.pending = this.pending.catch(() => undefined).then(() => this.closeStream());
-    return this.pending;
-  }
-
-  private async appendAndTrim(data: Buffer): Promise<void> {
-    await this.writeToStream(data);
-    this.currentSize += data.length;
-
-    if (this.currentSize > this.maxBytes) {
-      await this.trim();
-    }
-  }
-
-  private async closeStream(): Promise<void> {
-    if (this.writeStream.closed) {
+  try {
+    const stats = await handle.stat();
+    if (stats.size <= maxBytes) {
       return;
     }
 
-    await new Promise<void>((resolve, reject) => {
-      this.writeStream.end((error: NodeJS.ErrnoException | null) => {
-        if (error) {
-          reject(new LogWriteError(`Failed to close log file: ${this.logPath}`, error));
-          return;
-        }
-        resolve();
-      });
-    });
-  }
-
-  private async trim(): Promise<void> {
-    // Close the current stream before rewriting the file
-    await this.closeStream();
-
-    const keepBytes = Math.min(this.keepBytes, this.maxBytes);
-    let retained = Buffer.alloc(0);
-    let handle: FileHandle | null = null;
-
-    // Read the tail of the file to retain the most recent content
-    try {
-      handle = await open(this.logPath, 'r');
-    } catch {
-      handle = null;
+    const bytesToKeep = Math.min(keepBytes, stats.size);
+    const retained = Buffer.alloc(bytesToKeep);
+    if (bytesToKeep > 0) {
+      await handle.read(retained, 0, bytesToKeep, stats.size - bytesToKeep);
     }
 
-    if (handle !== null) {
-      try {
-        const stats = await handle.stat();
-        const bytesToKeep = Math.min(keepBytes, stats.size);
-        retained = Buffer.alloc(bytesToKeep);
-        if (bytesToKeep > 0) {
-          await handle.read(retained, 0, bytesToKeep, stats.size - bytesToKeep);
-        }
-      } finally {
-        await handle.close();
-      }
+    await writeFile(logPath, retained, { mode: 0o600 });
+  } finally {
+    await handle.close();
+  }
+}
+
+export function trimLogFileSync(logPath: string, maxBytes: number, keepRatio: number = DEFAULT_KEEP_RATIO): void {
+  if (maxBytes <= 0) {
+    throw new LogWriteError(`maxBytes must be positive. Received: ${String(maxBytes)}`);
+  }
+
+  if (keepRatio <= 0 || keepRatio >= 1) {
+    throw new LogWriteError(`keepRatio must be between 0 and 1. Received: ${String(keepRatio)}`);
+  }
+
+  let stats;
+  try {
+    stats = statSync(logPath);
+  } catch {
+    return;
+  }
+
+  if (stats.size <= maxBytes) {
+    return;
+  }
+
+  const keepBytes = Math.max(1, Math.min(Math.floor(maxBytes * keepRatio), maxBytes));
+  const bytesToKeep = Math.min(keepBytes, stats.size);
+  const retained = Buffer.alloc(bytesToKeep);
+  const handle = openSync(logPath, 'r');
+  try {
+    if (bytesToKeep > 0) {
+      readSync(handle, retained, 0, bytesToKeep, stats.size - bytesToKeep);
     }
-
-    // Rewrite the file with the retained content
-    await writeFile(this.logPath, retained, { mode: 0o600 });
-    this.currentSize = retained.length;
-
-    // Reopen the stream in append mode
-    this.writeStream = createWriteStream(this.logPath, { flags: 'a', mode: 0o600 });
+  } finally {
+    closeSync(handle);
   }
 
-  private async writeToStream(data: Buffer): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-      this.writeStream.write(data, (error) => {
-        if (error) {
-          reject(new LogWriteError(`Failed to write to log file: ${this.logPath}`, error));
-          return;
-        }
-        resolve();
-      });
-    });
-  }
+  writeFileSync(logPath, retained, { mode: 0o600 });
 }

--- a/packages/core/src/state/state-manager.ts
+++ b/packages/core/src/state/state-manager.ts
@@ -27,6 +27,7 @@ export interface ProcessState {
   startedAt?: string; // ISO 8601 timestamp
   stoppedAt?: string; // ISO 8601 timestamp
   logPath?: string; // Path to the log file
+  logMaxBytes?: number; // Maximum log size captured at start
   ports?: number[]; // Ports currently in use
 }
 


### PR DESCRIPTION
Writes process logs directly to file descriptors and trims logs at boundaries to prevent `portmux select` from hanging due to open stdout/stderr pipes.

Switches to direct file descriptor logging for stdout/stderr to resolve the hanging issue and adds log trimming for the same reason. Additionally, the change includes synchronous and asynchronous log trimming functions.