### PR TITLE
Adds global log controls

### DIFF
--- a/.changeset/global-log-controls.md
+++ b/.changeset/global-log-controls.md
@@ -1,0 +1,6 @@
+---
+'@portmux/core': patch
+'@portmux/cli': patch
+---
+
+Write process logs directly to file descriptors and trim only at boundaries to avoid hanging `portmux select`, move the log size cap to global config for per-user control, and add a global `logs.disabled` switch to skip log output entirely.

--- a/README.md
+++ b/README.md
@@ -210,8 +210,9 @@ portmux sync --all
 
 - `stdout`/`stderr` are written to `~/.config/portmux/logs/`; view with `portmux logs`.
 - Process state, PIDs, and reserved ports persist in `~/.config/portmux/` for reuse by `ps` and `logs`.
-- Log files are automatically trimmed to the newest content when they exceed 10MB by default; override per project via `logs.maxBytes` in `portmux.config.json`.
+- Log files are automatically trimmed to the newest content when they exceed 10MB by default; set a per-user cap via `logs.maxBytes` in `~/.config/portmux/config.json`.
 - Trimming runs at process start and when listing processes (`portmux ps`), keeping only the tail within the configured limit.
+- Disable logging globally by adding `"logs": { "disabled": true }` to `~/.config/portmux/config.json` (stdout/stderr are ignored when disabled).
 - Log cleanup: `portmux stop` removes the associated log file, and `portmux ps` prunes log files not referenced by any recorded process state. No separate prune command is required.
 
 ## Development

--- a/packages/cli/schemas/portmux.config.schema.json
+++ b/packages/cli/schemas/portmux.config.schema.json
@@ -12,9 +12,6 @@
     "runner": {
       "$ref": "#/$defs/runner"
     },
-    "logs": {
-      "$ref": "#/$defs/logs"
-    },
     "groups": {
       "type": "object",
       "minProperties": 1,
@@ -40,17 +37,6 @@
         }
       },
       "required": ["mode"]
-    },
-    "logs": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "maxBytes": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Maximum log file size in bytes before trimming keeps the newest content."
-        }
-      }
     },
     "group": {
       "type": "object",

--- a/packages/cli/src/commands/logs.test.ts
+++ b/packages/cli/src/commands/logs.test.ts
@@ -57,6 +57,17 @@ describe('runLogsCommand', () => {
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
+  it('exits with error when logging is disabled', () => {
+    listAllStates.mockReturnValue([
+      { group: 'group', process: 'proc', status: 'Running' as const, logsDisabled: true },
+    ]);
+
+    runLogsCommand('group', 'proc', { follow: false });
+
+    expect(console.error).toHaveBeenCalledWith('Error: Logging is disabled for process "proc"');
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
   it('exits with error when logPath is missing', () => {
     listAllStates.mockReturnValue([{ group: 'group', process: 'proc', status: 'Running' as const }]);
 

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -182,6 +182,12 @@ export function runLogsCommand(
 
     const state = processMatches[0];
 
+    if (state?.logsDisabled) {
+      console.error(chalk.red(`Error: Logging is disabled for process "${processName}"`));
+      process.exit(1);
+      return;
+    }
+
     if (!state?.logPath) {
       console.error(chalk.red(`Error: Log file path for process "${processName}" was not found`));
       process.exit(1);

--- a/packages/cli/src/commands/restart.test.ts
+++ b/packages/cli/src/commands/restart.test.ts
@@ -132,6 +132,24 @@ describe('runRestartCommand', () => {
     expect(console.log).toHaveBeenCalledWith('✓ Restarted process "worker"');
   });
 
+  it('passes disableLogs when logging is disabled globally', async () => {
+    vi.mocked(GroupManager.resolveGroupByName).mockReturnValue({
+      ...resolvedGroup,
+      logsDisabled: true,
+    });
+
+    await runRestartCommand('ws-one', 'api');
+
+    expect(ProcessManager.restartProcess).toHaveBeenCalledWith(
+      'group-instance-id',
+      'api',
+      'npm start',
+      expect.objectContaining({
+        disableLogs: true,
+      })
+    );
+  });
+
   it('logs ProcessRestartError failures', async () => {
     vi.mocked(ProcessManager.restartProcess).mockRejectedValueOnce(new ProcessRestartError('restart fail'));
 

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -53,6 +53,7 @@ function resolveGroupOrFallback(groupName?: string): ResolvedGroup {
         projectConfig: config,
         projectConfigPath: configPath,
         groupDefinitionName: targetGroup,
+        logsDisabled: false,
       };
     }
     throw error;
@@ -84,7 +85,8 @@ async function restartProcessesForGroup(
   }
 
   const processes = processNames ? groupDef.commands.filter((cmd) => processNames.has(cmd.name)) : groupDef.commands;
-  const logMaxBytes = resolvedGroup.projectConfig.logs?.maxBytes;
+  const logMaxBytes = resolvedGroup.logMaxBytes;
+  const disableLogs = resolvedGroup.logsDisabled === true;
 
   if (processes.length === 0) {
     const label = processNames?.size === 1 ? Array.from(processNames)[0] : undefined;
@@ -114,6 +116,7 @@ async function restartProcessesForGroup(
           worktreePath: resolvedGroup.path,
           ...(cmd.ports !== undefined && { ports: cmd.ports }),
           ...(logMaxBytes !== undefined && { logMaxBytes }),
+          ...(disableLogs && { disableLogs }),
         });
 
         console.log(chalk.green(`✓ Restarted process "${cmd.name}"`));

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -170,6 +170,24 @@ describe('runStartCommand', () => {
     );
   });
 
+  it('passes disableLogs when logging is disabled globally', async () => {
+    vi.mocked(GroupManager.resolveGroupByName).mockReturnValue({
+      ...resolvedGroup,
+      logsDisabled: true,
+    });
+
+    await runStartCommand('ws-one');
+
+    expect(ProcessManager.startProcess).toHaveBeenCalledWith(
+      'group-instance-id',
+      'api',
+      'npm start',
+      expect.objectContaining({
+        disableLogs: true,
+      })
+    );
+  });
+
   it('exits when config is missing', async () => {
     vi.mocked(GroupManager.resolveGroupAuto).mockImplementation(() => {
       throw new ConfigNotFoundError('missing');

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -101,7 +101,8 @@ export async function runStartCommand(
     }
 
     const projectRoot = resolvedGroup.path;
-    const logMaxBytes = resolvedGroup.projectConfig.logs?.maxBytes;
+    const logMaxBytes = resolvedGroup.logMaxBytes;
+    const disableLogs = resolvedGroup.logsDisabled === true;
     if (invokeOptions?.startAll && processName) {
       console.error(chalk.red('Error: --all cannot be combined with a process name'));
       process.exit(1);
@@ -158,6 +159,7 @@ export async function runStartCommand(
               ...(invokeOptions?.worktreeLabel !== undefined && { branch: invokeOptions.worktreeLabel }),
               ...(cmd.ports !== undefined && { ports: cmd.ports }),
               ...(logMaxBytes !== undefined && { logMaxBytes }),
+              ...(disableLogs && { disableLogs }),
             });
 
             console.log(chalk.green(`✓ Started process "${cmd.name}"`));

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -35,8 +35,10 @@ export const RunnerSchema = z.object({
 });
 
 /** Logs configuration schema. */
-export const LogsConfigSchema = z.object({
+/** Global logs configuration schema. */
+export const GlobalLogsConfigSchema = z.object({
   maxBytes: z.number().int().positive().optional(),
+  disabled: z.boolean().optional(),
 });
 
 /**
@@ -46,7 +48,6 @@ export const PortMuxConfigSchema = z
   .object({
     $schema: z.string().optional(),
     runner: RunnerSchema.optional(),
-    logs: LogsConfigSchema.optional(),
     groups: z.record(z.string(), GroupSchema),
   })
   .refine((data) => Object.keys(data.groups).length > 0, {
@@ -65,6 +66,7 @@ export const RepositorySchema = z.object({
  * Global configuration schema.
  */
 export const GlobalConfigSchema = z.object({
+  logs: GlobalLogsConfigSchema.optional(),
   repositories: z.record(z.string(), RepositorySchema),
 });
 
@@ -74,6 +76,6 @@ export const GlobalConfigSchema = z.object({
 export type PortMuxConfig = z.infer<typeof PortMuxConfigSchema>;
 export type Group = z.infer<typeof GroupSchema>;
 export type Command = z.infer<typeof CommandSchema>;
-export type LogsConfig = z.infer<typeof LogsConfigSchema>;
+export type GlobalLogsConfig = z.infer<typeof GlobalLogsConfigSchema>;
 export type GlobalConfig = z.infer<typeof GlobalConfigSchema>;
 export type Repository = z.infer<typeof RepositorySchema>;

--- a/packages/core/src/group/group-manager.ts
+++ b/packages/core/src/group/group-manager.ts
@@ -22,6 +22,8 @@ export interface ResolvedGroup {
   projectConfig: PortMuxConfig;
   projectConfigPath: string;
   groupDefinitionName: string;
+  logsDisabled?: boolean;
+  logMaxBytes?: number;
 }
 
 /**
@@ -237,6 +239,8 @@ export const GroupManager = {
       projectConfig,
       projectConfigPath,
       groupDefinitionName: mergedRepository.groupDefinitionName,
+      ...(merged.globalConfig.logs?.disabled === true && { logsDisabled: true }),
+      ...(merged.globalConfig.logs?.maxBytes !== undefined && { logMaxBytes: merged.globalConfig.logs.maxBytes }),
     };
   },
 
@@ -265,6 +269,8 @@ export const GroupManager = {
 
     // Load the global configuration
     const mergedConfig = ConfigManager.mergeGlobalAndProjectConfigs({ skipInvalid: true });
+    const globalLogsDisabled = mergedConfig?.globalConfig.logs?.disabled === true;
+    const globalLogMaxBytes = mergedConfig?.globalConfig.logs?.maxBytes;
     if (!mergedConfig) {
       // Fall back to the first group when no global config exists
       const firstGroupName = Object.keys(projectConfig.groups)[0];
@@ -278,6 +284,8 @@ export const GroupManager = {
         projectConfig,
         projectConfigPath,
         groupDefinitionName: firstGroupName,
+        ...(globalLogsDisabled && { logsDisabled: true }),
+        ...(globalLogMaxBytes !== undefined && { logMaxBytes: globalLogMaxBytes }),
       };
     }
 
@@ -294,6 +302,8 @@ export const GroupManager = {
             projectConfig: mergedRepository.projectConfig,
             projectConfigPath: mergedRepository.projectConfigPath,
             groupDefinitionName: mergedRepository.groupDefinitionName,
+            ...(globalLogsDisabled && { logsDisabled: true }),
+            ...(globalLogMaxBytes !== undefined && { logMaxBytes: globalLogMaxBytes }),
           };
         }
       }
@@ -312,6 +322,8 @@ export const GroupManager = {
         projectConfig,
         projectConfigPath,
         groupDefinitionName: firstGroupName,
+        ...(globalLogsDisabled && { logsDisabled: true }),
+        ...(globalLogMaxBytes !== undefined && { logMaxBytes: globalLogMaxBytes }),
       };
     }
 
@@ -346,6 +358,8 @@ export const GroupManager = {
           projectConfig: mergedRepository.projectConfig,
           projectConfigPath: mergedRepository.projectConfigPath,
           groupDefinitionName: mergedRepository.groupDefinitionName,
+          ...(globalLogsDisabled && { logsDisabled: true }),
+          ...(globalLogMaxBytes !== undefined && { logMaxBytes: globalLogMaxBytes }),
         };
       }
     }

--- a/packages/core/src/state/state-manager.ts
+++ b/packages/core/src/state/state-manager.ts
@@ -28,6 +28,7 @@ export interface ProcessState {
   stoppedAt?: string; // ISO 8601 timestamp
   logPath?: string; // Path to the log file
   logMaxBytes?: number; // Maximum log size captured at start
+  logsDisabled?: boolean; // Whether logging was disabled when started
   ports?: number[]; // Ports currently in use
 }
 

--- a/portmux.config.json
+++ b/portmux.config.json
@@ -1,8 +1,5 @@
 {
   "$schema": "~/.bun/install/global/node_modules/@portmux/cli/schemas/portmux.config.schema.json",
-  "logs": {
-    "maxBytes": 10485760
-  },
   "groups": {
     "app1": {
       "description": "",


### PR DESCRIPTION
Moves log size limit to global config for per-user control.

Adds a global `logs.disabled` switch to skip log output entirely.

These changes also ensure process logs are written directly to file descriptors and trimmed only at boundaries to avoid hanging `portmux select`.