### PR TITLE
Trims repository path in `ps` table output

### DIFF
--- a/.changeset/trim-ps-repo-path.md
+++ b/.changeset/trim-ps-repo-path.md
@@ -1,0 +1,5 @@
+---
+'@portmux/cli': patch
+---
+
+Remove repository path from the `ps` table output while keeping paths in the summary lines.

--- a/packages/cli/src/commands/ps.test.ts
+++ b/packages/cli/src/commands/ps.test.ts
@@ -65,7 +65,7 @@ describe('psCommand', () => {
     await runPs();
 
     expect(console.table).toHaveBeenCalledWith([
-      { Repository: 'repo-one:main (/repo/main)', Group: 'ws-one', Process: 'api', Status: 'Running', PID: 123 },
+      { Repository: 'repo-one:main', Group: 'ws-one', Process: 'api', Status: 'Running', PID: 123 },
       { Repository: 'instance-two', Group: 'instance-two', Process: 'worker', Status: 'Error', PID: '-' },
     ]);
     expect(console.log).toHaveBeenCalledWith('  ✓ repo-one:main (/repo/main)/api (PID: 123)');
@@ -103,7 +103,7 @@ describe('psCommand', () => {
 
     expect(console.table).toHaveBeenCalledWith([
       {
-        Repository: `repo-one:main (${displayPath})`,
+        Repository: 'repo-one:main',
         Group: 'repo-one:main',
         Process: 'api',
         Status: 'Running',

--- a/packages/cli/src/commands/ps.ts
+++ b/packages/cli/src/commands/ps.ts
@@ -5,8 +5,15 @@ import { shortenHomePath } from '../utils/path-label.js';
 
 export const psCommand: ReturnType<typeof createPsCommand> = createPsCommand();
 
-function formatRepositoryLabel(process: ReturnType<typeof ProcessManager.listProcesses>[number]): string {
+function formatRepositoryLabel(
+  process: ReturnType<typeof ProcessManager.listProcesses>[number],
+  options?: { includePath?: boolean }
+): string {
   const label = process.groupLabel ?? process.repositoryName ?? process.group;
+  if (options?.includePath === false) {
+    return label;
+  }
+
   const path = process.worktreePath ?? process.groupKey;
   if (path) {
     return `${label} (${shortenHomePath(path)})`;
@@ -30,7 +37,7 @@ function createPsCommand(): Command {
 
       // Display rows as a table
       const tableData = processes.map((p) => ({
-        Repository: formatRepositoryLabel(p),
+        Repository: formatRepositoryLabel(p, { includePath: false }),
         Group: formatGroupDisplay(p),
         Process: p.process,
         Status: p.status,


### PR DESCRIPTION
Removes the repository path from the `ps` table output for a cleaner display, while retaining the paths in the summary lines.

This change improves readability of the `ps` table, especially when dealing with long repository paths. The full path is still available in the summary for detailed information.